### PR TITLE
DUT change detection

### DIFF
--- a/src/WebHMIServer/src/DataSource/ADS/DataSource.cpp
+++ b/src/WebHMIServer/src/DataSource/ADS/DataSource.cpp
@@ -7,7 +7,12 @@
 
 using namespace std;
 
+//Note: This static impl is just to make debugging easier
 adsdatasrc_impl* static_impl;
+
+//TODO: prefer not use a single global variable
+//  But we need to be able to access the callback from a static function
+adsdatasrc* pAdsdatasrc = nullptr;
 
 adsdatasrc::adsdatasrc()
 {
@@ -21,9 +26,13 @@ adsdatasrc::adsdatasrc()
     impl->Addr.netId.b[4] = 1;
     impl->Addr.netId.b[5] = 1;
 
-    impl->pAddr->port = 851;
+    impl->Addr.port = 851;
 
+//    this->readPlcData();
+
+    //Note: This static impl is just to make debugging easier
     static_impl = impl;
+    pAdsdatasrc = this;
 }
 
 adsdatasrc::~adsdatasrc()
@@ -42,13 +51,17 @@ void adsdatasrc::readPlcData()
         Sleep(1000);
         cerr << "No PLC Connections, will try again " << '\n';
     }
-    registerDUTChangeCallback();
 }
 
-// Callback function
-void __stdcall SymbolTableChanged(AmsAddr* pAddr, AdsNotificationHeader* pNotification, ULONG hUser)
+void adsdatasrc::connect()
 {
-    cout << "Symbol table changed" << endl;
+    //this->registerDUTChangeCallback();
+    this->readPlcData();
+}
+
+void __stdcall SymbolChangedCallback(AmsAddr* pAddr, AdsNotificationHeader* pNotification, unsigned long hUser)
+{
+    pAdsdatasrc->readPlcData();
 }
 
 void adsdatasrc::registerDUTChangeCallback()
@@ -62,16 +75,15 @@ void adsdatasrc::registerDUTChangeCallback()
     // Specify attributes of the notification
     adsNotificationAttrib.cbLength = 1;
     adsNotificationAttrib.nTransMode = ADSTRANS_SERVERONCHA;
-    adsNotificationAttrib.nMaxDelay = 5000000; // 500ms
-    adsNotificationAttrib.nCycleTime = 5000000; // 500ms
-
+    adsNotificationAttrib.nMaxDelay = 50000; // 50ms
+    adsNotificationAttrib.nCycleTime = 50000; // 50ms
     // Start notification for changes to the symbol table
     nErr = AdsSyncAddDeviceNotificationReq(impl->pAddr,
                                            ADSIGRP_SYM_VERSION,
                                            0,
                                            &adsNotificationAttrib,
-                                           SymbolTableChanged,
-                                           NULL,
+                                           SymbolChangedCallback,
+                                           0,
                                            &this->adsChangeHandle);
     if (nErr) { cerr << "Error: AdsSyncAddDeviceNotificationReq: " << nErr << '\n';}
 }

--- a/src/WebHMIServer/src/DataSource/ADS/DataSource.h
+++ b/src/WebHMIServer/src/DataSource/ADS/DataSource.h
@@ -6,7 +6,6 @@
 class adsdatasrc : public DataSource {
 private:
     void* _impl;
-    unsigned long adsChangeHandle = 0;
     void gatherBaseTypeNames(crow::json::rvalue&                                packet,
                              std::string&                                       prefix,
                              std::vector<std::pair<std::string, std::string> >& names);
@@ -15,7 +14,9 @@ private:
                                     std::vector<std::pair<std::string, std::string> >& names);
 
     void registerDUTChangeCallback();
+
 public:
+    unsigned long adsChangeHandle = 0;
     adsdatasrc(/* args */);
     ~adsdatasrc();
 
@@ -28,6 +29,7 @@ public:
     void writeSymbolValue(std::string symbolName);
     void writeSymbolValue(crow::json::rvalue symbolNames);
 
+    void connect();
     void readPlcData();
     bool ready();
 

--- a/src/WebHMIServer/src/DataSource/ADS/DataSource_impl.h
+++ b/src/WebHMIServer/src/DataSource/ADS/DataSource_impl.h
@@ -66,6 +66,7 @@ public:
                                        PAdsSymbolEntry pAdsSymbolEntry);
 
     CAdsParseSymbols* parsedSymbols = NULL;
+    void SymbolTableChanged(AmsAddr*, AdsNotificationHeader*, unsigned long);
     bool ready = false;
 };
 


### PR DESCRIPTION
Add support for detecting when a download happens. If we detect a download, we need to through out all the cache, get new symbol handles and redownload the symbol and DUT data

NOTE: This PR currently doesn't work