### PR TITLE
add a default static site server to simplify getting started

### DIFF
--- a/example/HMI/README.md
+++ b/example/HMI/README.md
@@ -27,7 +27,13 @@ machine = new LUX.Machine({
 
 Open Index.html with your favorite server.
 
-The [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) extension for VSCode is recommended. Once installed, right click on `index.html` and select `Open with Live Server`.
+Option 1: Run the following command to start a local server
+
+```
+npm start
+```
+
+Option 2: The [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) extension for VSCode is recommended. Once installed, right click on `index.html` and select `Open with Live Server`.
 
 The client should display in a browser:
 ![Lux client](images/lux_local.JPG)

--- a/example/HMI/package.json
+++ b/example/HMI/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "http-server .\\"
   },
   "keywords": [],
   "author": "",
@@ -17,5 +18,8 @@
     "bootstrap": "^3.3.4",
     "handlebars": "*",
     "jquery": "*"
+  },
+  "devDependencies": {
+    "http-server": "*"
   }
 }


### PR DESCRIPTION
# What 

Install a default static server with the HMI

# Why

This simplifies the setup for a new user trying it out